### PR TITLE
Add tests for ML client module

### DIFF
--- a/machine-learning-client/tests/test_extract_keypoints_from_hagrid_unittest.py
+++ b/machine-learning-client/tests/test_extract_keypoints_from_hagrid_unittest.py
@@ -1,10 +1,13 @@
+"""Unit tests for extract_keypoints_from_hagrid module."""
+
+# pylint: disable=import-error,too-few-public-methods
+
 import unittest
 import numpy as np
 
 from src import extract_keypoints_from_hagrid as hagrid_mod
 
 
-# ---- Fake landmark structures ----
 class FakeLandmark:
     """Single x,y,z landmark."""
 
@@ -24,8 +27,9 @@ class FakeHandLandmarks:
         ]
 
 
-# ---- Feature extraction tests ----
 class TestExtractLandmarkVector(unittest.TestCase):
+    """Tests for extract_landmark_vector."""
+
     def test_vector_shape_and_dtype(self):
         """Output shape = NUM_LANDMARKS * DIM_PER_LM, dtype = float32."""
         fake = FakeHandLandmarks()


### PR DESCRIPTION
I added a set of pytest tests for the ML client, which includes tests for the MLP model, keypoint extraction, model loading, MongoDB insert behavior, and a mocked run of the main loop. There’s also a test for the Hagrid dataset feature extraction.

Everything passes locally, and coverage for live_mediapipe_mlp.py is over 80%. The overall src coverage is over 30%。